### PR TITLE
feat: refactor client for parallel usage

### DIFF
--- a/boondmanager/api/opportunities.py
+++ b/boondmanager/api/opportunities.py
@@ -52,5 +52,5 @@ class Opportunities(DefaultEndpointMixin, BaseClient):
     allowed_methods = ['GET', 'POST', 'DELETE', 'PUT']
     list_uri = '/opportunities'
     single_uri = '/opportunities/{}'
-    tabs = ['rights', 'informations', 'attached-flags', 'simulation', 'positionings', 'actions', 'projects',
+    tabs = ['rights', 'information', 'attached-flags', 'simulation', 'positionings', 'actions', 'projects',
             'download', 'tasks']

--- a/boondmanager/api/purchases.py
+++ b/boondmanager/api/purchases.py
@@ -50,4 +50,4 @@ class Purchases(DefaultEndpointMixin, BaseClient):
     allowed_methods = ['GET', 'POST', 'DELETE', 'PUT']
     list_uri = '/purchases'
     single_uri = '/purchases/{}'
-    tabs = ['rights', 'informations', 'attached-flags', 'simulation', 'payments', 'download', 'tasks']
+    tabs = ['rights', 'information', 'attached-flags', 'simulation', 'payments', 'download', 'tasks']


### PR DESCRIPTION
To make sure that concurrent calls for get and request can be made, it is easier to move some of the logic from the class level to the function level.

For example, this will ensure that the data retrieved after a request is always associated to this specific request
